### PR TITLE
NOT calling setPlainPassword() as this clears the password property

### DIFF
--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -235,7 +235,7 @@ class User implements AdvancedUserInterface, Serializable
     
     public function eraseCredentials()
     {
-        $this->setPlainPassword(null);
+        $this->plainPassword = null;
     }
     
     public function isAccountNonExpired()


### PR DESCRIPTION
eraseCredentials() is called after login, just to make sure you don't store any
plain text passwords on the User object and put it into the session or something.
However, by calling setPlainPassword(), not only was the plainPassword cleared,
the encoded `password` property was *also* cleared. This meant that the User
object was serialized into the session with *no* password. On the next request,
when the User was refreshed, the refreshed User object and the serialized User
object appeared to have different passwords, suggesting that the user had changed
his password and remotely and our session should be terminated.

I hope this helps - this is a very common problem to hit - your other setup looks very cool :).